### PR TITLE
Use constructor-based injection

### DIFF
--- a/src/main/java/com/example/customerservice/config/GrpcConfig.java
+++ b/src/main/java/com/example/customerservice/config/GrpcConfig.java
@@ -1,5 +1,7 @@
 package com.example.customerservice.config;
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 @Configuration
 @ImportAutoConfiguration({
@@ -20,4 +22,9 @@ import org.springframework.context.annotation.Configuration;
 })
 
 public class GrpcConfig {
+
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
 }

--- a/src/main/java/com/example/customerservice/mappers/CustomerMapper.java
+++ b/src/main/java/com/example/customerservice/mappers/CustomerMapper.java
@@ -1,13 +1,15 @@
 package com.example.customerservice.mappers;
 import com.customer.service.customerservice.stub.CustomerServiceOuterClass;
 import com.example.customerservice.entities.Customer;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
 @Component
 
+@RequiredArgsConstructor
 public class CustomerMapper {
-    private  ModelMapper modelMapper=new ModelMapper();
+    private final ModelMapper modelMapper;
     public CustomerServiceOuterClass.Customer fromCustomer(Customer customer){
         return this.modelMapper.map(customer,  CustomerServiceOuterClass.Customer.class);
 

--- a/src/main/java/com/example/customerservice/web/CustomerGRPCService.java
+++ b/src/main/java/com/example/customerservice/web/CustomerGRPCService.java
@@ -8,21 +8,18 @@ import com.example.customerservice.repository.CustomerRepository;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Component
 @GrpcService
+@RequiredArgsConstructor
 public class CustomerGRPCService extends CustomerServiceGrpc.CustomerServiceImplBase{
 
-    @Autowired
-    CustomerRepository customerRepository;
-    @Autowired
-    CustomerMapper customerMapper;
+    private final CustomerRepository customerRepository;
+    private final CustomerMapper customerMapper;
 
     @Override
     public void


### PR DESCRIPTION
## Summary
- use constructor injection for gRPC service
- inject ModelMapper through configuration

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687f3cbb7a088327af8d3002dcdb1fd6